### PR TITLE
Upgrade rollup related dependencies and update config to suppress the warning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1656,9 +1656,9 @@
       }
     },
     "fs-extra": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.0.tgz",
-      "integrity": "sha512-EglNDLRpmaTWiD/qraZn6HREAEAHJcJOmxNEYwq6xeMKnVMAy3GUcFB+wXt2C6k4CNvB/mP1y/U3dzvKKj5OtQ==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.1.2",
@@ -4548,12 +4548,12 @@
       }
     },
     "rollup-plugin-typescript2": {
-      "version": "0.18.1",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-typescript2/-/rollup-plugin-typescript2-0.18.1.tgz",
-      "integrity": "sha512-aR2m5NCCAUV/KpcKgCWX6Giy8rTko9z92b5t0NX9eZyjOftCvcdDFa1C9Ze/9yp590hnRymr5hG0O9SAXi1oUg==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-typescript2/-/rollup-plugin-typescript2-0.19.2.tgz",
+      "integrity": "sha512-DRG7SaYX0QzBIz6rII5nm1UkiceS95r8mJjujugybyIueNF3auvzGTHMK62O7As/0q5RHjXsOguWOUv+KJKLFA==",
       "dev": true,
       "requires": {
-        "fs-extra": "7.0.0",
+        "fs-extra": "7.0.1",
         "resolve": "1.8.1",
         "rollup-pluginutils": "2.3.3",
         "tslib": "1.9.3"

--- a/package-lock.json
+++ b/package-lock.json
@@ -3270,9 +3270,9 @@
       }
     },
     "js-cleanup": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/js-cleanup/-/js-cleanup-1.0.0.tgz",
-      "integrity": "sha512-gT33849UQki2Ek5NJM9eCH1ZEMjzMfyE881kmfv51hxO4K+TgH+qBIt9RZjczrV02wFqNDSVCk8pE9p78I3cIw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/js-cleanup/-/js-cleanup-1.0.1.tgz",
+      "integrity": "sha512-wyHeWKqbcQV78/tiMJ6pgJrkG7p2u3b2xX9IJFvvurpJL9/++89dHfkUebhWvSMS84LG0uQ7BnG5GGyAzY21Ag==",
       "dev": true,
       "requires": {
         "magic-string": "^0.25.1",
@@ -4478,13 +4478,13 @@
       }
     },
     "rollup-plugin-cleanup": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-cleanup/-/rollup-plugin-cleanup-3.1.0.tgz",
-      "integrity": "sha512-HA6PyX6tvN3rK6VgGemqPcDC62vYL9FawIng7IciaXbj/wJ4ydY13JmN+S+zIOtVaqpJhB3lTH24l2YVGJlC8A==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-cleanup/-/rollup-plugin-cleanup-3.1.1.tgz",
+      "integrity": "sha512-wMS9JQm4ShvlMqno1pOfqvh0yYgNLO2ZgmzDsVvKuDt4XCn+9DcMoUwRQ5t9p9b113dR5FhPFFUHnvvQ/yuEtA==",
       "dev": true,
       "requires": {
-        "js-cleanup": "^1.0.0",
-        "rollup-pluginutils": "^2.3.0"
+        "js-cleanup": "^1.0.1",
+        "rollup-pluginutils": "^2.3.3"
       }
     },
     "rollup-plugin-commonjs": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4459,14 +4459,14 @@
       }
     },
     "rollup": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.0.2.tgz",
-      "integrity": "sha512-FkkSrWUVo1WliS+/GIgEmKQPILubgVdBRTWampfdhkasxx7sM2nfwSfKiX3paIBVnN0HG3DvkTy13RfjkyBX9w==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.1.2.tgz",
+      "integrity": "sha512-OkdMxqMl8pWoQc5D8y1cIinYQPPLV8ZkfLgCzL6SytXeNA2P7UHynEQXI9tYxuAjAMsSyvRaWnyJDLHMxq0XAg==",
       "dev": true,
       "requires": {
         "@types/estree": "0.0.39",
         "@types/node": "*",
-        "acorn": "^6.0.4"
+        "acorn": "^6.0.5"
       },
       "dependencies": {
         "acorn": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@vue/test-utils": "1.0.0-beta.28",
     "jest": "23.6.0",
     "rollup": "1.1.2",
-    "rollup-plugin-cleanup": "3.1.0",
+    "rollup-plugin-cleanup": "3.1.1",
     "rollup-plugin-commonjs": "9.2.0",
     "rollup-plugin-json": "3.1.0",
     "rollup-plugin-node-resolve": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@types/jest": "23.3.13",
     "@vue/test-utils": "1.0.0-beta.28",
     "jest": "23.6.0",
-    "rollup": "1.0.2",
+    "rollup": "1.1.2",
     "rollup-plugin-cleanup": "3.1.0",
     "rollup-plugin-commonjs": "9.2.0",
     "rollup-plugin-json": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "rollup-plugin-commonjs": "9.2.0",
     "rollup-plugin-json": "3.1.0",
     "rollup-plugin-node-resolve": "4.0.0",
-    "rollup-plugin-typescript2": "0.18.1",
+    "rollup-plugin-typescript2": "0.19.2",
     "ts-jest": "23.10.5",
     "typescript": "3.2.4",
     "vue": "2.5.22",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -29,7 +29,8 @@ export default {
 
   output: {
     file: pkg.main,
-    format: "cjs"
+    format: "cjs",
+    exports: "named"
   },
 
   external: ["@vue/test-utils"]


### PR DESCRIPTION
Close #7 
Close #8 
Close #9 

```
[hmsk@] $ npm run build

> jest-matcher-vue-test-utils@1.3.0 build /Users/hmsk/src/github.com/hmsk/jest-matcher-vue-test-utils
> rollup -c


./src/index.ts → ./dist/index.js...
(!) Mixing named and default exports
Consumers of your bundle will have to use bundle['default'] to access the default export, which may not be what you want. Use `output.exports: 'named'` to disable this warning
```