### PR TITLE
Show friendly diff of unmatched payloads

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -462,7 +462,6 @@
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/@jest/types/-/types-24.9.0.tgz",
       "integrity": "sha512-XKK7ze1apu5JWQ5eZjHITP66AX+QsLlbaJRBGYr8pNzwcAE2JVkwnf0yqjHTsDRcjR0mujy/NmZMXw5kl+kGBw==",
-      "dev": true,
       "requires": {
         "@types/istanbul-lib-coverage": "^2.0.0",
         "@types/istanbul-reports": "^1.1.1",
@@ -519,14 +518,12 @@
     "@types/istanbul-lib-coverage": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",
-      "integrity": "sha512-hRJD2ahnnpLgsj6KWMYSrmXkM3rm2Dl1qkx6IOFD5FnuNPXJIG5L0dhgKXCYTRMGzU4n0wImQ/xfmRc4POUFlg==",
-      "dev": true
+      "integrity": "sha512-hRJD2ahnnpLgsj6KWMYSrmXkM3rm2Dl1qkx6IOFD5FnuNPXJIG5L0dhgKXCYTRMGzU4n0wImQ/xfmRc4POUFlg=="
     },
     "@types/istanbul-lib-report": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-1.1.1.tgz",
       "integrity": "sha512-3BUTyMzbZa2DtDI2BkERNC6jJw2Mr2Y0oGI7mRxYNBPxppbtEK1F66u3bKwU2g+wxwWI7PAoRpJnOY1grJqzHg==",
-      "dev": true,
       "requires": {
         "@types/istanbul-lib-coverage": "*"
       }
@@ -535,7 +532,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-1.1.1.tgz",
       "integrity": "sha512-UpYjBi8xefVChsCoBpKShdxTllC9pwISirfoZsUa2AAdQg/Jd2KQGtSbw+ya7GPo7x/wAPlH6JBhKhAsXUEZNA==",
-      "dev": true,
       "requires": {
         "@types/istanbul-lib-coverage": "*",
         "@types/istanbul-lib-report": "*"
@@ -593,7 +589,6 @@
       "version": "13.0.2",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.2.tgz",
       "integrity": "sha512-lwwgizwk/bIIU+3ELORkyuOgDjCh7zuWDFqRtPPhhVgq9N1F7CvLNKg1TX4f2duwtKQ0p044Au9r1PLIXHrIzQ==",
-      "dev": true,
       "requires": {
         "@types/yargs-parser": "*"
       }
@@ -601,8 +596,7 @@
     "@types/yargs-parser": {
       "version": "13.0.0",
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-13.0.0.tgz",
-      "integrity": "sha512-wBlsw+8n21e6eTd4yVv8YD/E3xq0O6nNnJIquutAsFGE7EyMKz7W6RNT6BRu1SmdgmlCZ9tb0X+j+D6HGr8pZw==",
-      "dev": true
+      "integrity": "sha512-wBlsw+8n21e6eTd4yVv8YD/E3xq0O6nNnJIquutAsFGE7EyMKz7W6RNT6BRu1SmdgmlCZ9tb0X+j+D6HGr8pZw=="
     },
     "@vue/test-utils": {
       "version": "1.0.0-beta.29",
@@ -684,7 +678,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
       "requires": {
         "color-convert": "^1.9.0"
       }
@@ -1195,7 +1188,6 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
       "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-      "dev": true,
       "requires": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -1268,7 +1260,6 @@
       "version": "1.9.2",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.2.tgz",
       "integrity": "sha512-3NUJZdhMhcdPn8vJ9v2UQJoH0qqoGUkYTgFEPZaPjEtwmmKUfNV46zZmgB2M5M4DCEQHMaCfWHCxiBflLm04Tg==",
-      "dev": true,
       "requires": {
         "color-name": "1.1.1"
       }
@@ -1276,8 +1267,7 @@
     "color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz",
-      "integrity": "sha1-SxQVMEz1ACjqgWQ2Q72C6gWANok=",
-      "dev": true
+      "integrity": "sha1-SxQVMEz1ACjqgWQ2Q72C6gWANok="
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -1534,8 +1524,7 @@
     "diff-sequences": {
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-24.9.0.tgz",
-      "integrity": "sha512-Dj6Wk3tWyTE+Fo1rW8v0Xhwk80um6yFYKbuAxc9c3EZxIHFDYwbi34Uk42u1CdnIiVorvt4RmlSDjIPyzGC2ew==",
-      "dev": true
+      "integrity": "sha512-Dj6Wk3tWyTE+Fo1rW8v0Xhwk80um6yFYKbuAxc9c3EZxIHFDYwbi34Uk42u1CdnIiVorvt4RmlSDjIPyzGC2ew=="
     },
     "dom-event-types": {
       "version": "1.0.0",
@@ -1634,8 +1623,7 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "escodegen": {
       "version": "1.12.0",
@@ -2742,8 +2730,7 @@
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "dev": true
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
     },
     "has-symbols": {
       "version": "1.0.0",
@@ -3227,7 +3214,6 @@
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-24.9.0.tgz",
       "integrity": "sha512-qMfrTs8AdJE2iqrTp0hzh7kTd2PQWrsFyj9tORoKmu32xjPjeE4NyjVRDz8ybYwqS2ik8N4hsIpiVTyFeo2lBQ==",
-      "dev": true,
       "requires": {
         "chalk": "^2.0.1",
         "diff-sequences": "^24.9.0",
@@ -3287,8 +3273,7 @@
     "jest-get-type": {
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-24.9.0.tgz",
-      "integrity": "sha512-lUseMzAley4LhIcpSP9Jf+fTrQ4a1yHQwLNeeVa2cEmbCGeoZAtYPOIv8JaxLD/sUpKxetKGP+gsHl8f8TSj8Q==",
-      "dev": true
+      "integrity": "sha512-lUseMzAley4LhIcpSP9Jf+fTrQ4a1yHQwLNeeVa2cEmbCGeoZAtYPOIv8JaxLD/sUpKxetKGP+gsHl8f8TSj8Q=="
     },
     "jest-haste-map": {
       "version": "24.9.0",
@@ -4473,7 +4458,6 @@
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.9.0.tgz",
       "integrity": "sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==",
-      "dev": true,
       "requires": {
         "@jest/types": "^24.9.0",
         "ansi-regex": "^4.0.0",
@@ -4484,8 +4468,7 @@
         "ansi-regex": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-          "dev": true
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
         }
       }
     },
@@ -4542,8 +4525,7 @@
     "react-is": {
       "version": "16.9.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.9.0.tgz",
-      "integrity": "sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw==",
-      "dev": true
+      "integrity": "sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw=="
     },
     "read-pkg": {
       "version": "3.0.0",
@@ -5337,7 +5319,6 @@
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
       "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-      "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,9 @@
     "url": "https://github.com/hmsk/jest-matcher-vue-test-utils/issues"
   },
   "homepage": "https://github.com/hmsk/jest-matcher-vue-test-utils#readme",
+  "dependencies": {
+    "jest-diff": ">=22.0"
+  },
   "devDependencies": {
     "@types/jest": "24.0.18",
     "@vue/test-utils": "1.0.0-beta.29",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -33,5 +33,8 @@ export default {
     exports: "named"
   },
 
-  external: ["@vue/test-utils"]
+  external: [
+    "@vue/test-utils",
+    "jest-diff"
+  ]
 }

--- a/src/matchers/toDispatch.ts
+++ b/src/matchers/toDispatch.ts
@@ -1,5 +1,6 @@
 import Vue from "vue";
 import { Wrapper } from "@vue/test-utils";
+import diff from "jest-diff";
 import { MatcherResult } from "../utils";
 
 declare global {
@@ -38,7 +39,8 @@ export default function<V extends Vue> (
             pass = true;
             message = `The function dispatched the "${actionType}" type on Vuex Store`;
           } else {
-            message = `The function dispatched the "${actionType}" type but the payload is not matched on Vuex Store`;
+            // TODO: Show diff for all dispatched payloads
+            message = `The function dispatched the "${actionType}" type but the payload is not matched on Vuex Store\n${diff(payload, action.payload, { bAnnotation: "Dispatched" })}`;
           }
         } else {
           pass = true;

--- a/src/matchers/toHaveDispatched.ts
+++ b/src/matchers/toHaveDispatched.ts
@@ -1,6 +1,7 @@
 import Vue from "vue";
 import { ActionPayload } from "vuex";
 import { Wrapper } from "@vue/test-utils";
+import diff from "jest-diff";
 import { MatcherResult } from "../utils";
 import { storeKey } from "../vuex-plugin";
 
@@ -42,7 +43,10 @@ export default function<V extends Vue> (
           pass = true;
           message = `"${actionType}" action has been dispatched with expected payload`;
         } else {
-          message = `"${actionType}" action has been dispatched, but payload isn't matched to the expectation`;
+          const diffs = matched.map((action, i): string | null => {
+            return `"${actionType}" action #${i} payloads:\n\n${diff(payload, action.payload, { bAnnotation: "Dispatched" })}`;
+          }).join("\n\n");
+          message = `"${actionType}" action has been dispatched, but payload isn't matched to the expectation\n\n${diffs}`;
         }
       } else {
         pass = true;

--- a/src/matchers/toHaveEmitted.ts
+++ b/src/matchers/toHaveEmitted.ts
@@ -1,5 +1,6 @@
 import Vue from "vue";
 import { Wrapper } from "@vue/test-utils";
+import diff from "jest-diff";
 import { MatcherResult } from "../utils";
 
 declare global {
@@ -39,7 +40,12 @@ export default function<V extends Vue> (
     message = pass ?
       () => `The "${eventName}" event was emitted with the expected payload` :
         emitted.length > 0 ?
-          () => `The "${eventName}" event was emitted but the payload is not matched` :
+          () => {
+            const diffs = emitted.map((event, i): string | null => {
+              return `'${eventName}' event #${i} payloads:\n\n${diff(payloads, event, { bAnnotation: "Emitted" })}`;
+            }).join("\n\n");
+            return `The "${eventName}" event was emitted but the payload is not matched\n\n${diffs}`
+          } :
           () => `The "${eventName}" event was never emitted`;
   } else {
     pass = emitted.length > 0;

--- a/test/emit.test.ts
+++ b/test/emit.test.ts
@@ -97,12 +97,30 @@ describe("toHaveEmitted with payload", () => {
       expect(result.message()).toBe('The "special" event was never emitted');
     });
 
-    it("returns false if the event is emitted but the payload is not matched", () => {
-      const wrapper = shallowMount(Component);
-      emitEvent(wrapper, "special", { value: "anything" });
-      const result = toHaveEmitted.bind(fakeJestContext(false))(wrapper, "special", "something");
-      expect(result.pass).toBe(false);
-      expect(result.message()).toBe('The "special" event was emitted but the payload is not matched');
+    describe("when the event is emitted but the payload is not matched", () => {
+      const subject = () => {
+        const wrapper = shallowMount(Component);
+        emitEvent(wrapper, "special", { value: "anything" });
+        return toHaveEmitted.bind(fakeJestContext(false))(wrapper, "special", "some text", { value: "something" });
+      };
+
+      it("returns false", () => {
+        expect(subject().pass).toBe(false);
+      });
+
+      it("tells the reason", () => {
+        expect(subject().message()).toContain('The "special" event was emitted but the payload is not matched');
+      });
+
+      it("shows the diff of payloads", () => {
+        const message = subject().message();
+        expect(message).toContain("'special' event #0 payloads:");
+        expect(message).toContain("- Expected");
+        expect(message).toContain("+ Emitted");
+        expect(message).toContain('-   "some text"');
+        expect(message).toContain('-     "value": "something"');
+        expect(message).toContain('+     "value": "anything"');
+      });
     });
   });
 

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -62,11 +62,27 @@ describe("toDispatch", () => {
       expect(result.message()).toBe('The function dispatched the "awesomeAction" type on Vuex Store');
     });
 
-    it("returns false if the action is dispatched by the function, but payload is not matched", () => {
-      const wrapper = mountComponent();
-      const result = toDispatch.bind(fakeJestContext(false))(() => customDispatch(wrapper, "hello"), wrapper, "awesomeAction", "hellooooo");
-      expect(result.pass).toBe(false);
-      expect(result.message()).toBe('The function dispatched the "awesomeAction" type but the payload is not matched on Vuex Store');
+    describe("the action is dispatched by the function, but the payload is not matched", () => {
+      const subject = () => {
+        const wrapper = mountComponent();
+        return toDispatch.bind(fakeJestContext(false))(() => customDispatch(wrapper, "hello?"), wrapper, "awesomeAction", "hellooooo");
+      };
+
+      it("returns false", () => {
+        expect(subject().pass).toBe(false);
+      });
+
+      it("message tells the reason", () => {
+        expect(subject().message()).toContain('The function dispatched the "awesomeAction" type but the payload is not matched on Vuex Store');
+      });
+
+      it("message tells the reason", () => {
+        const message = subject().message();
+        expect(message).toContain("- Expected");
+        expect(message).toContain("- hellooooo");
+        expect(message).toContain("+ Dispatched");
+        expect(message).toContain("+ hello?");
+      });
     });
 
     it("returns false if the wrapper's Vue instance doesn't have Vuex Store", () => {

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -158,12 +158,29 @@ describe("toHaveDispatched", () => {
       expect(result.message()).toBe('"awesomeAction" action has been dispatched with expected payload');
     });
 
-    it("returns false if the action type has been dispatched, but payload is not matched", () => {
-      const wrapper = mountComponent();
-      customDispatch(wrapper, "hello")
-      const result = toHaveDispatched.bind(fakeJestContext(false))(wrapper, "awesomeAction", "hello");
-      expect(result.pass).toBe(false);
-      expect(result.message()).toBe('"awesomeAction" action has been dispatched, but payload isn\'t matched to the expectation');
+    describe("when the action type has been dispatched, but payload is not matched", () => {
+      const subject = () => {
+        const wrapper = mountComponent();
+        customDispatch(wrapper, "hello")
+        return toHaveDispatched.bind(fakeJestContext(false))(wrapper, "awesomeAction", "good bye");
+      };
+
+      it("returns false", () => {
+        expect(subject().pass).toBe(false);
+      });
+
+      it("tells the reason", () => {
+        expect(subject().message()).toContain('"awesomeAction" action has been dispatched, but payload isn\'t matched to the expectation');
+      });
+
+      it("shows the diff of payloads", () => {
+        const message = subject().message();
+        expect(message).toContain('"awesomeAction" action #0 payloads:');
+        expect(message).toContain("- Expected");
+        expect(message).toContain("- good bye");
+        expect(message).toContain("+ Dispatched");
+        expect(message).toContain("+ hello");
+      });
     });
 
     it("returns false if the wrapper's Vue instance doesn't have Vuex Store", () => {


### PR DESCRIPTION
Resolve #25 

Currently, the assertion error message for `toEmit`, `toHaveEmitted`, `toDispatch` and `toHaveDispatched` don't show any detail when event/action is triggered but payloads are not matched. So, it's a bit annoying to find out the test coder's mistakes.

This PR provides friendly diff for the message using `jest-diff` as like `toEqual` does.

![image](https://user-images.githubusercontent.com/85887/64918825-6b5f1c80-d758-11e9-91e4-28764cfb5fb8.png)

![image](https://user-images.githubusercontent.com/85887/64918835-93e71680-d758-11e9-8192-65e9c81f7dc2.png)